### PR TITLE
makefile: ignore errors if policy isnt built yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ MINIMAL_POLICY_SOURCES = policy/minimal.cil
 all: clean policy.$(POLICY_VERSION)
 
 clean:
-	$(RM) policy.$(POLICY_VERSION) file_contexts
+	$(RM) -f policy.$(POLICY_VERSION) file_contexts
 
 $(POLICY_VERSION): $(BASE_POLICY_SOURCES) $(MINIMAL_POLICY_SOURCES)
 	$(SECILC) --policyvers=$(POLICY_VERSION) --o="$@" $^


### PR DESCRIPTION
Same as in dssp2-standard, ignore errors when `make clean` is run when
the policy or file_contexts files have yet to be built.

Signed-off-by: Gary Tierney <gary.tierney@gmx.com>